### PR TITLE
Added Identity with custom Board authorization

### DIFF
--- a/WorthBoards.Api/Configurations/AuthenticationConfiguration.cs
+++ b/WorthBoards.Api/Configurations/AuthenticationConfiguration.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+using WorthBoards.Common.Enums;
+
+namespace WorthBoards.Api.Configurations
+{
+    public static class AuthenticationConfiguration
+    {
+        public static WebApplicationBuilder ConfigureAuthentication(this WebApplicationBuilder builder)
+        {
+            var keyValue = TryGetConfigValue(builder.Configuration, "WBJwtKey");
+            builder.Services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+                options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
+            }).AddJwtBearer(options =>
+            {
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidIssuer = TryGetConfigValue(builder.Configuration, "WBIssuer"),
+                    ValidAudience = TryGetConfigValue(builder.Configuration, "WBAudience"),
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(keyValue!))
+                };
+            });
+
+            return builder;
+        }
+
+        private static string? TryGetConfigValue(IConfiguration configuration, string key)
+        {
+            var value = configuration[key];
+
+            if (value is null)
+            {
+                Console.WriteLine($"[ERROR] Missing configuration value for key '{key}'");
+                Environment.Exit(1);
+            }
+
+            return value;
+        }
+    }
+}

--- a/WorthBoards.Api/Configurations/AuthorizationConfiguration.cs
+++ b/WorthBoards.Api/Configurations/AuthorizationConfiguration.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using System.Diagnostics;
+using WorthBoards.Api.Utils;
+using WorthBoards.Common.Enums;
+
+namespace WorthBoards.Api.Configurations
+{
+    public static class AuthorizationConfiguration
+    {
+        public static WebApplicationBuilder ConfigureAuthorization(this WebApplicationBuilder builder)
+        {
+            builder.Services.AddAuthorization(options =>
+            {
+                foreach (UserRoleEnum role in Enum.GetValues(typeof(UserRoleEnum)))
+                {
+                    AddRolePolicy(options, role);
+                }
+            });
+
+            return builder;
+        }
+
+        private static void AddRolePolicy(AuthorizationOptions options, UserRoleEnum role)
+        {
+            string roleStr = role.ToString();
+            options.AddPolicy(roleStr, policy =>
+            {
+                policy.Requirements.Add(new PermissionRequirement(role));
+            });
+        }
+    }
+}

--- a/WorthBoards.Api/Configurations/SwaggerConfiguration.cs
+++ b/WorthBoards.Api/Configurations/SwaggerConfiguration.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.OpenApi.Models;
+
+namespace WorthBoards.Api.Configurations
+{
+    public static class SwaggerConfiguration
+    {
+        public static WebApplicationBuilder ConfigureSwagger(this WebApplicationBuilder builder)
+        {
+            builder.Services.AddEndpointsApiExplorer();
+            builder.Services.AddSwaggerGen(options =>
+            {
+                options.SwaggerDoc("v1", new OpenApiInfo { Title = "Worth Boards API", Version = "v1" });
+
+                // Add security definition
+                options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+                {
+                    Name = "Authorization",
+                    Type = SecuritySchemeType.ApiKey,
+                    Scheme = "Bearer",
+                    BearerFormat = "JWT",
+                    In = ParameterLocation.Header,
+                    Description = "Enter 'Bearer' followed by a space and your JWT token."
+                });
+
+                // Add security requirement
+                options.AddSecurityRequirement(new OpenApiSecurityRequirement
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.SecurityScheme,
+                                Id = "Bearer"
+                            }
+                        },
+                        new string[] { }
+                    }
+                });
+            });
+
+            return builder;
+        }
+    }
+}

--- a/WorthBoards.Api/Controllers/AuthController.cs
+++ b/WorthBoards.Api/Controllers/AuthController.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
+using WorthBoards.Api.Utils;
 using WorthBoards.Business.Dtos.Identity;
 using WorthBoards.Business.Services.Interfaces;
+using WorthBoards.Common.Enums;
 
 namespace WorthBoards.Api.Controllers
 {
@@ -9,7 +10,8 @@ namespace WorthBoards.Api.Controllers
     [ApiController]
     public class AuthController(IAuthService authService) : ControllerBase
     {
-        [HttpPost("register")]
+        [AuthorizeRole(UserRoleEnum.VIEWER)] // TODO: remove tag
+        [HttpPost("/register")]
         public async Task<IActionResult> RegisterUserAsync([FromBody] UserRegisterRequest request)
         {
             var response = await authService.RegisterUserAsync(request);

--- a/WorthBoards.Api/Controllers/AuthController.cs
+++ b/WorthBoards.Api/Controllers/AuthController.cs
@@ -10,9 +10,8 @@ namespace WorthBoards.Api.Controllers
     [ApiController]
     public class AuthController(IAuthService authService) : ControllerBase
     {
-        [AuthorizeRole(UserRoleEnum.VIEWER)] // TODO: remove tag
         [HttpPost("/register")]
-        public async Task<IActionResult> RegisterUserAsync([FromBody] UserRegisterRequest request)
+        public async Task<IActionResult> RegisterUserAsync(int Id, [FromBody] UserRegisterRequest request)
         {
             var response = await authService.RegisterUserAsync(request);
             return Ok(response);

--- a/WorthBoards.Api/Controllers/AuthController.cs
+++ b/WorthBoards.Api/Controllers/AuthController.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using WorthBoards.Business.Dtos.Identity;
+using WorthBoards.Business.Services.Interfaces;
+
+namespace WorthBoards.Api.Controllers
+{
+    [Route("/")]
+    [ApiController]
+    public class AuthController(IAuthService authService) : ControllerBase
+    {
+        [HttpPost("register")]
+        public async Task<IActionResult> RegisterUserAsync([FromBody] UserRegisterRequest request)
+        {
+            var response = await authService.RegisterUserAsync(request);
+            return Ok(response);
+        }
+
+        [HttpPost("/login")]
+        public async Task<IActionResult> LoginUserAsync([FromBody] UserLoginRequest credentials)
+        {
+            var response = await authService.LoginUserAsync(credentials);
+            return Ok(response);
+        }
+    }
+}

--- a/WorthBoards.Api/Controllers/AuthController.cs
+++ b/WorthBoards.Api/Controllers/AuthController.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using WorthBoards.Api.Utils;
 using WorthBoards.Business.Dtos.Identity;
 using WorthBoards.Business.Services.Interfaces;
-using WorthBoards.Common.Enums;
 
 namespace WorthBoards.Api.Controllers
 {
@@ -11,7 +9,7 @@ namespace WorthBoards.Api.Controllers
     public class AuthController(IAuthService authService) : ControllerBase
     {
         [HttpPost("/register")]
-        public async Task<IActionResult> RegisterUserAsync(int Id, [FromBody] UserRegisterRequest request)
+        public async Task<IActionResult> RegisterUserAsync([FromBody] UserRegisterRequest request)
         {
             var response = await authService.RegisterUserAsync(request);
             return Ok(response);

--- a/WorthBoards.Api/DependencyInjection.cs
+++ b/WorthBoards.Api/DependencyInjection.cs
@@ -1,10 +1,13 @@
-﻿namespace Microsoft.Extensions.DependencyInjection
+﻿using Microsoft.AspNetCore.Authorization;
+using WorthBoards.Api.Utils;
+
+namespace Microsoft.Extensions.DependencyInjection
 {
     public static class DependencyInjection
     {
         public static IServiceCollection AddApiServices(this IServiceCollection services, IConfiguration configuration)
         {
-            //Register stuff for api layer here
+            services.AddSingleton<IAuthorizationHandler, PermissionHandler>();
 
             return services;
         }

--- a/WorthBoards.Api/Program.cs
+++ b/WorthBoards.Api/Program.cs
@@ -1,4 +1,8 @@
+using WorthBoards.Api.Configurations;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.ConfigureSwagger();
 
 // Add services to the container.
 builder.Services.AddAuthentication();
@@ -8,9 +12,6 @@ builder.Services.AddBusinessServices(builder.Configuration);
 builder.Services.AddDataServices(builder.Configuration);
 
 builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
 
 builder.WebHost.UseUrls("https://localhost:5000");
 

--- a/WorthBoards.Api/Program.cs
+++ b/WorthBoards.Api/Program.cs
@@ -1,11 +1,16 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 using WorthBoards.Api.Configurations;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.ConfigureSwagger();
+builder
+    .ConfigureSwagger()
+    .ConfigureAuthentication()
+    .ConfigureAuthorization();
 
 // Add services to the container.
-builder.Services.AddAuthentication();
 
 builder.Services.AddApiServices(builder.Configuration);
 builder.Services.AddBusinessServices(builder.Configuration);

--- a/WorthBoards.Api/Program.cs
+++ b/WorthBoards.Api/Program.cs
@@ -13,7 +13,8 @@ builder.Services.AddDataServices(builder.Configuration);
 
 builder.Services.AddControllers();
 
-builder.WebHost.UseUrls("https://localhost:5000");
+var baseUrl = builder.Configuration.GetValue<string>("BaseUrl") ?? string.Empty;
+builder.WebHost.UseUrls(baseUrl);
 
 builder.Services.AddCors(options =>
 {

--- a/WorthBoards.Api/Program.cs
+++ b/WorthBoards.Api/Program.cs
@@ -12,7 +12,7 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-builder.WebHost.UseUrls("http://localhost:3000");
+builder.WebHost.UseUrls("http://localhost:5000");
 
 builder.Services.AddCors(options =>
 {

--- a/WorthBoards.Api/Program.cs
+++ b/WorthBoards.Api/Program.cs
@@ -12,7 +12,7 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-builder.WebHost.UseUrls("http://localhost:5000");
+builder.WebHost.UseUrls("https://localhost:5000");
 
 builder.Services.AddCors(options =>
 {

--- a/WorthBoards.Api/Utils/AuthorizeRoleAttribute.cs
+++ b/WorthBoards.Api/Utils/AuthorizeRoleAttribute.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using WorthBoards.Common.Enums;
+
+namespace WorthBoards.Api.Utils
+{
+    public class AuthorizeRoleAttribute : AuthorizeAttribute
+    {
+        public AuthorizeRoleAttribute(UserRoleEnum role)
+        {
+            Policy = role.ToString();
+        }
+    }
+}

--- a/WorthBoards.Api/Utils/PermissionHandler.cs
+++ b/WorthBoards.Api/Utils/PermissionHandler.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace WorthBoards.Api.Utils
+{
+    public class PermissionHandler : AuthorizationHandler<PermissionRequirement>
+    {
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
+        {
+            var httpContext = (context.Resource as DefaultHttpContext)?.HttpContext;
+            var routeValues = httpContext?.Request.RouteValues;
+
+            if (routeValues == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            var boardIdObj = routeValues.FirstOrDefault(kv => kv.Key.EndsWith("Id")).Value;
+            var boardId = boardIdObj?.ToString();
+            if (string.IsNullOrEmpty(boardId))
+            {
+                return Task.CompletedTask;
+            }
+
+            var hasPermission = context.User.Claims
+                .Where(c => c.Type == "BoardPermission")
+                .Any(c => c.Value == $"{boardId}:{requirement.Role}");
+
+            if (hasPermission)
+            {
+                context.Succeed(requirement);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WorthBoards.Api/Utils/PermissionRequirement.cs
+++ b/WorthBoards.Api/Utils/PermissionRequirement.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using WorthBoards.Common.Enums;
+
+namespace WorthBoards.Api.Utils
+{
+    public class PermissionRequirement : IAuthorizationRequirement
+    {
+        public string Role { get; set; }
+
+        public PermissionRequirement(UserRoleEnum role)
+        {
+            Role = role.ToString();
+        }
+    }
+}

--- a/WorthBoards.Api/WorthBoards.Api.csproj
+++ b/WorthBoards.Api/WorthBoards.Api.csproj
@@ -12,10 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Controllers\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\WorthBoards.Business\WorthBoards.Business.csproj" />
     <ProjectReference Include="..\WorthBoards.Common\WorthBoards.Common.csproj" />
   </ItemGroup>

--- a/WorthBoards.Api/WorthBoards.Api.csproj
+++ b/WorthBoards.Api/WorthBoards.Api.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.14" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/WorthBoards.Api/WorthBoards.Api.csproj.user
+++ b/WorthBoards.Api/WorthBoards.Api.csproj.user
@@ -2,6 +2,8 @@
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ActiveDebugProfile>https</ActiveDebugProfile>
+    <Controller_SelectedScaffolderID>ApiControllerEmptyScaffolder</Controller_SelectedScaffolderID>
+    <Controller_SelectedScaffolderCategoryPath>root/Common/Api</Controller_SelectedScaffolderCategoryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>

--- a/WorthBoards.Api/WorthBoards.Api.csproj.user
+++ b/WorthBoards.Api/WorthBoards.Api.csproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ActiveDebugProfile>https</ActiveDebugProfile>
+    <ActiveDebugProfile>IIS Express</ActiveDebugProfile>
     <Controller_SelectedScaffolderID>ApiControllerEmptyScaffolder</Controller_SelectedScaffolderID>
     <Controller_SelectedScaffolderCategoryPath>root/Common/Api</Controller_SelectedScaffolderCategoryPath>
   </PropertyGroup>

--- a/WorthBoards.Api/appsettings.json
+++ b/WorthBoards.Api/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "BaseUrl": "https://localhost:5000",
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/WorthBoards.Business/AutoMapper/MappingProfile.cs
+++ b/WorthBoards.Business/AutoMapper/MappingProfile.cs
@@ -1,0 +1,16 @@
+﻿using AutoMapper;
+using WorthBoards.Business.Dtos.Identity;
+using WorthBoards.Data.Identity;
+
+namespace WorthBoards.Business.AutoMapper
+{
+    public class MappingProfile : Profile
+    {
+        public MappingProfile()
+        {
+            // User
+            CreateMap<ApplicationUser, UserResponse>();
+            CreateMap<UserRequest, ApplicationUser>();
+        }
+    }
+}

--- a/WorthBoards.Business/AutoMapper/MappingProfile.cs
+++ b/WorthBoards.Business/AutoMapper/MappingProfile.cs
@@ -11,6 +11,7 @@ namespace WorthBoards.Business.AutoMapper
             // User
             CreateMap<ApplicationUser, UserResponse>();
             CreateMap<UserRequest, ApplicationUser>();
+            CreateMap<UserRegisterRequest, ApplicationUser>();
         }
     }
 }

--- a/WorthBoards.Business/DependencyInjection.cs
+++ b/WorthBoards.Business/DependencyInjection.cs
@@ -1,4 +1,9 @@
 ﻿using Microsoft.Extensions.Configuration;
+using WorthBoards.Business.AutoMapper;
+using WorthBoards.Business.Services;
+using WorthBoards.Business.Services.Interfaces;
+using WorthBoards.Business.Utils.Interfaces;
+using WorthBoards.Business.Utils;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -6,7 +11,9 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddBusinessServices(this IServiceCollection services, IConfiguration configuration)
         {
-            //Register stuff for business layer here
+            services.AddAutoMapper(typeof(MappingProfile));
+            services.AddScoped<IAuthService, AuthService>();
+            services.AddScoped<ITokenGenerator, TokenGenerator>();
 
             return services;
         }

--- a/WorthBoards.Business/DependencyInjection.cs
+++ b/WorthBoards.Business/DependencyInjection.cs
@@ -4,6 +4,7 @@ using WorthBoards.Business.Services;
 using WorthBoards.Business.Services.Interfaces;
 using WorthBoards.Business.Utils.Interfaces;
 using WorthBoards.Business.Utils;
+using Microsoft.AspNetCore.Authentication;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -11,9 +12,11 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddBusinessServices(this IServiceCollection services, IConfiguration configuration)
         {
+
             services.AddAutoMapper(typeof(MappingProfile));
             services.AddScoped<IAuthService, AuthService>();
             services.AddScoped<ITokenGenerator, TokenGenerator>();
+            services.AddScoped<IClaimsTransformation, ClaimsTransformation>();
 
             return services;
         }

--- a/WorthBoards.Business/Dtos/Identity/PasswordRecoveryResponse.cs
+++ b/WorthBoards.Business/Dtos/Identity/PasswordRecoveryResponse.cs
@@ -1,0 +1,4 @@
+﻿namespace WorthBoards.Business.Dtos.Identity
+{
+    public record PasswordRecoveryResponse(string Message);
+}

--- a/WorthBoards.Business/Dtos/Identity/UserLoginRequest.cs
+++ b/WorthBoards.Business/Dtos/Identity/UserLoginRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace WorthBoards.Business.Dtos.Identity
+{
+    public record UserLoginRequest(
+        string UserName,
+        string Password
+    );
+}

--- a/WorthBoards.Business/Dtos/Identity/UserLoginResponse.cs
+++ b/WorthBoards.Business/Dtos/Identity/UserLoginResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace WorthBoards.Business.Dtos.Identity
+{
+    public record UserLoginResponse(
+        int Id,
+        string UserName,
+        string JwtToken
+    );
+}

--- a/WorthBoards.Business/Dtos/Identity/UserRegisterRequest.cs
+++ b/WorthBoards.Business/Dtos/Identity/UserRegisterRequest.cs
@@ -1,0 +1,10 @@
+﻿namespace WorthBoards.Business.Dtos.Identity
+{
+    public record UserRegisterRequest(
+        string FirstName,
+        string LastName,
+        string UserName,
+        string Email,
+        string Password
+    );
+}

--- a/WorthBoards.Business/Dtos/Identity/UserRequest.cs
+++ b/WorthBoards.Business/Dtos/Identity/UserRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace WorthBoards.Business.Dtos.Identity
+{
+    public record UserRequest(
+        string FirstName,
+        string LastName,
+        string UserName,
+        string Email
+    );
+}

--- a/WorthBoards.Business/Dtos/Identity/UserResponse.cs
+++ b/WorthBoards.Business/Dtos/Identity/UserResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace WorthBoards.Business.Dtos.Identity
+{
+    public record UserResponse(
+        int Id,
+        string UserName,
+        string FirstName,
+        string LastName,
+        string Email
+    );
+}

--- a/WorthBoards.Business/Services/AuthService.cs
+++ b/WorthBoards.Business/Services/AuthService.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Identity;
+using WorthBoards.Business.Dtos.Identity;
+using WorthBoards.Business.Services.Interfaces;
+using WorthBoards.Data.Identity;
+
+namespace WorthBoards.Business.Services
+{
+    public class AuthService(
+        UserManager<ApplicationUser> userManager,
+        SignInManager<ApplicationUser> signInManager,
+        RoleManager<ApplicationRole> roleManager
+    ) : IAuthService
+    {
+        public Task<UserLoginResponse> LoginUserAsync(UserLoginRequest credentials)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<UserResponse> RegisterUserAsync(UserRegisterRequest registerUser)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/WorthBoards.Business/Services/AuthService.cs
+++ b/WorthBoards.Business/Services/AuthService.cs
@@ -1,6 +1,10 @@
-﻿using Microsoft.AspNetCore.Identity;
+﻿using AutoMapper;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
 using WorthBoards.Business.Dtos.Identity;
 using WorthBoards.Business.Services.Interfaces;
+using WorthBoards.Business.Utils.Interfaces;
 using WorthBoards.Data.Identity;
 
 namespace WorthBoards.Business.Services
@@ -8,17 +12,48 @@ namespace WorthBoards.Business.Services
     public class AuthService(
         UserManager<ApplicationUser> userManager,
         SignInManager<ApplicationUser> signInManager,
-        RoleManager<ApplicationRole> roleManager
+        IMapper mapper,
+        ITokenGenerator tokenGenerator
     ) : IAuthService
     {
-        public Task<UserLoginResponse> LoginUserAsync(UserLoginRequest credentials)
+        public async Task<UserLoginResponse> LoginUserAsync(UserLoginRequest credentials)
         {
-            throw new NotImplementedException();
+            var user = await userManager.FindByNameAsync(credentials.UserName);
+
+            // TODO: Add custom exception handle
+            ArgumentNullException.ThrowIfNull(user);
+
+            var result = await signInManager.CheckPasswordSignInAsync(user, credentials.Password, false);
+
+            // TODO: Add custom exception handle
+            if (!result.Succeeded)
+                throw new UnauthorizedAccessException("Invalid Login credentials.");
+
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+                new Claim(ClaimTypes.Name, user.UserName ?? string.Empty),
+                new Claim(ClaimTypes.Email, user.Email ?? string.Empty)
+            };
+
+            var jwtToken = tokenGenerator.GenerateJwtToken(claims);
+            
+            return new UserLoginResponse(user.Id, credentials.UserName, jwtToken);
         }
 
-        public Task<UserResponse> RegisterUserAsync(UserRegisterRequest registerUser)
+        public async Task<UserResponse> RegisterUserAsync(UserRegisterRequest registerUser)
         {
-            throw new NotImplementedException();
+            var user = mapper.Map<ApplicationUser>(registerUser);
+
+            user.CreationDate = DateTime.UtcNow;
+
+            var response = await userManager.CreateAsync(user, registerUser.Password);
+
+            // TODO: Add custom exception handle
+            if (!response.Succeeded)
+                throw new DbUpdateException("Failed to register user");
+
+            return mapper.Map<UserResponse>(user);
         }
     }
 }

--- a/WorthBoards.Business/Services/Interfaces/IAuthService.cs
+++ b/WorthBoards.Business/Services/Interfaces/IAuthService.cs
@@ -1,0 +1,10 @@
+﻿using WorthBoards.Business.Dtos.Identity;
+
+namespace WorthBoards.Business.Services.Interfaces
+{
+    public interface IAuthService
+    {
+        Task<UserResponse> RegisterUserAsync(UserRegisterRequest registerUser);
+        Task<UserLoginResponse> LoginUserAsync(UserLoginRequest credentials);
+    }
+}

--- a/WorthBoards.Business/Utils/ClaimsTransformation.cs
+++ b/WorthBoards.Business/Utils/ClaimsTransformation.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using WorthBoards.Data.Database;
+
+namespace WorthBoards.Business.Utils
+{
+    public class ClaimsTransformation(ApplicationDbContext context) : IClaimsTransformation
+    {
+        public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
+        {
+            var identity = principal.Identity as ClaimsIdentity;
+            if (identity == null || !identity.IsAuthenticated)
+                return principal;
+
+            var userId = identity.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+                return principal;
+
+            // Remove old board claims
+            var existingClaims = identity.FindAll("BoardPermission").ToList();
+            foreach (var claim in existingClaims)
+            {
+                identity.RemoveClaim(claim);
+            }
+
+            // Fetch latest board roles from database
+            var boardRoles = await context.BoardOnUsers
+                .Where(bu => bu.UserId == int.Parse(userId))
+                .Select(bu => new Claim("BoardPermission", $"{bu.BoardId}:{bu.UserRole}"))
+                .ToListAsync();
+
+            identity.AddClaims(boardRoles);
+
+            return principal;
+        }
+    }
+}

--- a/WorthBoards.Business/Utils/Interfaces/ITokenGenerator.cs
+++ b/WorthBoards.Business/Utils/Interfaces/ITokenGenerator.cs
@@ -1,0 +1,9 @@
+﻿using System.Security.Claims;
+
+namespace WorthBoards.Business.Utils.Interfaces
+{
+    public interface ITokenGenerator
+    {
+        public string GenerateJwtToken(List<Claim> claims);
+    }
+}

--- a/WorthBoards.Business/Utils/TokenGenerator.cs
+++ b/WorthBoards.Business/Utils/TokenGenerator.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using WorthBoards.Business.Utils.Interfaces;
+
+namespace WorthBoards.Business.Utils
+{
+    public class TokenGenerator(IConfiguration configuration) : ITokenGenerator
+    {
+        public string GenerateJwtToken(List<Claim> claims)
+        {
+            var secretKey = configuration["WBJwtKey"];
+            var issuer = configuration["WBIssuer"];
+            var audience = configuration["WBAudience"];
+
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secretKey!));
+            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+            var jwtToken = new JwtSecurityToken
+            (
+                issuer: issuer,
+                audience: audience,
+                claims: claims,
+                expires: DateTime.UtcNow.AddMinutes(30),
+                signingCredentials: creds
+            );
+
+            return new JwtSecurityTokenHandler().WriteToken(jwtToken);
+        }
+    }
+}

--- a/WorthBoards.Business/WorthBoards.Business.csproj
+++ b/WorthBoards.Business/WorthBoards.Business.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="14.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />
   </ItemGroup>
 

--- a/WorthBoards.Business/WorthBoards.Business.csproj
+++ b/WorthBoards.Business/WorthBoards.Business.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Services\" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WorthBoards.Data/Database/ApplicationDbContext.cs
+++ b/WorthBoards.Data/Database/ApplicationDbContext.cs
@@ -19,10 +19,10 @@ namespace WorthBoards.Data.Database
         public DbSet<NotificationOnUser> NotificationsOnUsers { get; set; }
         public DbSet<TaskOnUser> TasksOnUsers { get; set; }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        protected override void OnModelCreating(ModelBuilder builder)
         {
-            Linker.LinkAll(modelBuilder);
-            base.OnModelCreating(modelBuilder);
+            Linker.LinkAll(builder);
+            base.OnModelCreating(builder);
         }
     }
 }

--- a/WorthBoards.Data/DependencyInjection.cs
+++ b/WorthBoards.Data/DependencyInjection.cs
@@ -10,14 +10,12 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddDataServices(this IServiceCollection services, IConfiguration configuration)
         {
-            //Register stuff for data layer here
-
             var connectionString = Environment.GetEnvironmentVariable("DATABASE_URL") ?? configuration.GetConnectionString("WorthBoardsConnection");
 
             services.AddDbContext<ApplicationDbContext>(options =>
                 options.UseNpgsql(connectionString, npgsqlOptions => npgsqlOptions.MigrationsAssembly("WorthBoards.Data")));
 
-            var builder = services.AddIdentityCore<ApplicationUser>(options =>
+            services.AddIdentityCore<ApplicationUser>(options =>
             {
                 // Password settings.
                 options.Password.RequireDigit = true;
@@ -35,12 +33,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 // User settings.
                 options.User.AllowedUserNameCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+";
                 options.User.RequireUniqueEmail = true;
-            });
-
-            builder = new IdentityBuilder(builder.UserType, typeof(ApplicationRole), builder.Services);
-            builder
+            })
                 .AddEntityFrameworkStores<ApplicationDbContext>()
-                .AddRoleManager<RoleManager<ApplicationRole>>()
                 .AddSignInManager<SignInManager<ApplicationUser>>()
                 .AddDefaultTokenProviders();
 

--- a/WorthBoards.Data/Identity/ApplicationUser.cs
+++ b/WorthBoards.Data/Identity/ApplicationUser.cs
@@ -10,6 +10,6 @@ namespace WorthBoards.Data.Identity
         [MaxLength(30)]
         public required string LastName { get; set; }
         public required DateTime CreationDate { get; set; }
-        public required string ImageURL { get; set; }
+        public string? ImageURL { get; set; }
     }
 }

--- a/WorthBoards.Data/Migrations/20250321130644_UserImageNullable.Designer.cs
+++ b/WorthBoards.Data/Migrations/20250321130644_UserImageNullable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WorthBoards.Data.Database;
@@ -11,9 +12,11 @@ using WorthBoards.Data.Database;
 namespace WorthBoards.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250321130644_UserImageNullable")]
+    partial class UserImageNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WorthBoards.Data/Migrations/20250321130644_UserImageNullable.cs
+++ b/WorthBoards.Data/Migrations/20250321130644_UserImageNullable.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WorthBoards.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class UserImageNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ImageURL",
+                table: "AspNetUsers",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ImageURL",
+                table: "AspNetUsers",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
## New features
- Added AutoMapper
- Swagger setup
- Authorization with Jwt Bearer tokens
- Claims based role authorization.
- Jwt tokens are updated after every Http request (to check for changed permissions)

## Usage
- In Board controller methods add `[AuthorizeRole(UserRoleEnum.VIEWER)]` attributes, where it is necessary.
- Http attributes which use `[AuthorizeRole]` attribute MUST contain the string `"Id"` in the route to specify board Id. (For example `[HttpPost("{boardId}/create")]`)